### PR TITLE
Add installation steps for repos and packages for RHEL

### DIFF
--- a/lab1_ansible_install.adoc
+++ b/lab1_ansible_install.adoc
@@ -208,6 +208,7 @@ The following subsections provide steps to install Ansible and `git` for
 the following Linux distributions:
 
 * Fedora
+* Red Hat Enterprise Linux (RHEL)
 * CentOS
 * Ubuntu
 
@@ -221,6 +222,25 @@ As a `sudo` user,
 .Install Ansible and Git
 ----
 sudo dnf -y install ansible git
+----
+
+=== RHEL - Ansible & Git Installation Instructions
+
+The preferred method to install Ansible and `git` on RHEL is using the 
+`yum` package manager.
+
+As a `sudo` user, perform the following steps.
+
+.Enable the following repositories
+----
+sudo subscription-manager repos --enable=rhel-7-server-rpms --enable=rhel-7-server-ansible-2-rpms
+----
+
+As a `sudo` user, install the following packages
+
+.Install Ansible and Git
+----
+sudo yum -y install ansible git
 ----
 
 === CentOS - Ansible & Git Installation Instructions


### PR DESCRIPTION
Adds RHEL steps to lab1. Not sure if you want `rhel-7-server-rpms` in the instructions, that's kind of implied, but left it in for completeness.